### PR TITLE
make state machine transformer non-blocking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,122 +1,151 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.github.davidmoten</groupId>
-		<artifactId>sonatype-parent</artifactId>
-		<version>0.1</version>
-	</parent>
+    <parent>
+        <groupId>com.github.davidmoten</groupId>
+        <artifactId>sonatype-parent</artifactId>
+        <version>0.1</version>
+    </parent>
 
-	<artifactId>rxjava-extras</artifactId>
-	<version>0.6.4-SNAPSHOT</version>
+    <artifactId>rxjava-extras</artifactId>
+    <version>0.6.4-SNAPSHOT</version>
 
-	<name>${project.artifactId}</name>
-	<description>RxJava utilities</description>
-	<packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>RxJava utilities</description>
+    <packaging>jar</packaging>
 
-	<url>http://github.com/davidmoten/rxjava-extras</url>
+    <url>http://github.com/davidmoten/rxjava-extras</url>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<rxjava.version>1.0.14</rxjava.version>
-		<jmh.version>1.10.5</jmh.version>
-		<exec.version>1.4.0</exec.version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <rxjava.version>1.0.14</rxjava.version>
+        <jmh.version>1.10.5</jmh.version>
+        <exec.version>1.4.0</exec.version>
+        <slf4j.version>1.7.10</slf4j.version>
 
-		<cobertura.version>2.6</cobertura.version>
-		<checkstyle.version>2.11</checkstyle.version>
-		<findbugs.version>2.5.4</findbugs.version>
-		<javadoc.version>2.9.1</javadoc.version>
-		<pmd.version>3.0.1</pmd.version>
-		<jdepend.version>2.0-beta-2</jdepend.version>
-		<javancss.version>2.0</javancss.version>
-		<project.info.version>2.4</project.info.version>
-		<jxr.version>2.4</jxr.version>
-		<taglist.version>2.4</taglist.version>
-		<m3.site.version>3.3</m3.site.version>
-		<changelog.version>2.2</changelog.version>
-		<coverage.reports.dir>${project.build.directory}/target/coverage-reports</coverage.reports.dir>
-	</properties>
+        <cobertura.version>2.6</cobertura.version>
+        <checkstyle.version>2.11</checkstyle.version>
+        <findbugs.version>2.5.4</findbugs.version>
+        <javadoc.version>2.9.1</javadoc.version>
+        <pmd.version>3.0.1</pmd.version>
+        <jdepend.version>2.0-beta-2</jdepend.version>
+        <javancss.version>2.0</javancss.version>
+        <project.info.version>2.4</project.info.version>
+        <jxr.version>2.4</jxr.version>
+        <taglist.version>2.4</taglist.version>
+        <m3.site.version>3.3</m3.site.version>
+        <changelog.version>2.2</changelog.version>
+        <coverage.reports.dir>${project.build.directory}/target/coverage-reports</coverage.reports.dir>
+    </properties>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
 
-	<ciManagement>
-		<system>CloudBees</system>
-		<url>https://xuml-tools.ci.cloudbees.com</url>
-	</ciManagement>
+    <ciManagement>
+        <system>CloudBees</system>
+        <url>https://xuml-tools.ci.cloudbees.com</url>
+    </ciManagement>
 
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/davidmoten/rxjava-extras/issues</url>
-	</issueManagement>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/davidmoten/rxjava-extras/issues</url>
+    </issueManagement>
 
-	<inceptionYear>2013</inceptionYear>
-	<developers>
-		<developer>
-			<id>dave</id>
-			<name>Dave Moten</name>
-			<url>https://github.com/davidmoten/</url>
-			<roles>
-				<role>architect</role>
-				<role>developer</role>
-			</roles>
-			<timezone>+10</timezone>
-		</developer>
-	</developers>
+    <inceptionYear>2013</inceptionYear>
+    <developers>
+        <developer>
+            <id>dave</id>
+            <name>Dave Moten</name>
+            <url>https://github.com/davidmoten/</url>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
+            <timezone>+10</timezone>
+        </developer>
+    </developers>
 
-	<scm>
-		<connection>scm:git:https://github.com/davidmoten/rxjava-extras.git</connection>
-		<developerConnection>scm:git:https://github.com/davidmoten/rxjava-extras.git</developerConnection>
-		<url>scm:git:https://github.com:davidmoten/rxjava-extras.git</url>
-		<tag>0.6</tag>
-	</scm>
+    <scm>
+        <connection>scm:git:https://github.com/davidmoten/rxjava-extras.git</connection>
+        <developerConnection>scm:git:https://github.com/davidmoten/rxjava-extras.git</developerConnection>
+        <url>scm:git:https://github.com:davidmoten/rxjava-extras.git</url>
+        <tag>0.6</tag>
+    </scm>
 
-	<dependencies>
-		<dependency>
-			<groupId>io.reactivex</groupId>
-			<artifactId>rxjava</artifactId>
-			<version>${rxjava.version}</version>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>${rxjava.version}</version>
+        </dependency>
 
-		<!-- Test Dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>compile</scope>
-			<optional>true</optional>
-		</dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.github.davidmoten</groupId>
+            <artifactId>rxjava-slf4j</artifactId>
+            <version>0.5.4</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.openjdk.jmh</groupId>
-			<artifactId>jmh-core</artifactId>
-			<version>${jmh.version}</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>18.0</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <artifactId>log4j</artifactId>
+            <groupId>log4j</groupId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>com.esotericsoftware</groupId>
-			<artifactId>kryo</artifactId>
-			<version>3.0.3</version>
-			<optional>true</optional>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>3.0.3</version>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>com.github.davidmoten</groupId>
@@ -126,175 +155,174 @@
         </dependency>
 
 
-	</dependencies>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-					<source>${maven.compiler.target}</source>
-					<target>${maven.compiler.target}</target>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>${maven.compiler.target}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
 
-			<plugin>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>${m3.site.version}</version>
-				<executions>
-					<execution>
-						<id>attach-descriptor</id>
-						<goals>
-							<goal>attach-descriptor</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<reportPlugins>
-						<!-- this one should go first so that it is available to other plugins 
-							when they run -->
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-jxr-plugin</artifactId>
-							<version>${jxr.version}</version>
-							<configuration>
-								<aggregate>true</aggregate>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>cobertura-maven-plugin</artifactId>
-							<version>${cobertura.version}</version>
-							<configuration>
-								<aggregate>false</aggregate>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>${checkstyle.version}</version>
-							<configuration>
-								<includeTestSourceDirectory>true</includeTestSourceDirectory>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-pmd-plugin</artifactId>
-							<version>${pmd.version}</version>
-							<configuration>
-								<targetJdk>${maven.compiler.target}</targetJdk>
-								<aggregate>true</aggregate>
-							</configuration>
-						</plugin>
-						<!-- <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId> 
-							<version>${findbugs.version}</version> <configuration> <xmlOutput>true</xmlOutput> 
-							<effort>Max</effort> </configuration> </plugin> -->
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>jdepend-maven-plugin</artifactId>
-							<version>${jdepend.version}</version>
-						</plugin>
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>javancss-maven-plugin</artifactId>
-							<version>${javancss.version}</version>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-project-info-reports-plugin</artifactId>
-							<version>${project.info.version}</version>
-							<configuration>
-								<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-								<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>taglist-maven-plugin</artifactId>
-							<version>${taglist.version}</version>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>${javadoc.version}</version>
-							<configuration>
-								<aggregate>true</aggregate>
-							</configuration>
-						</plugin>
-						<!-- commented this plugin out because cannot run offline (e.g. at 
-							home) -->
-						<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-changelog-plugin</artifactId> 
-							<version>${changelog.version}</version> <configuration> <username>${svn.username}</username> 
-							<password>${svn.password}</password> </configuration> </plugin> -->
-					</reportPlugins>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${m3.site.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-descriptor</id>
+                        <goals>
+                            <goal>attach-descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <reportPlugins>
+                        <!-- this one should go first so that it is available to other plugins when they 
+                            run -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-jxr-plugin</artifactId>
+                            <version>${jxr.version}</version>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>cobertura-maven-plugin</artifactId>
+                            <version>${cobertura.version}</version>
+                            <configuration>
+                                <aggregate>false</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-checkstyle-plugin</artifactId>
+                            <version>${checkstyle.version}</version>
+                            <configuration>
+                                <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-pmd-plugin</artifactId>
+                            <version>${pmd.version}</version>
+                            <configuration>
+                                <targetJdk>${maven.compiler.target}</targetJdk>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <!-- <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId> 
+                            <version>${findbugs.version}</version> <configuration> <xmlOutput>true</xmlOutput> <effort>Max</effort> 
+                            </configuration> </plugin> -->
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>jdepend-maven-plugin</artifactId>
+                            <version>${jdepend.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>javancss-maven-plugin</artifactId>
+                            <version>${javancss.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>${project.info.version}</version>
+                            <configuration>
+                                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>taglist-maven-plugin</artifactId>
+                            <version>${taglist.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>${javadoc.version}</version>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <!-- commented this plugin out because cannot run offline (e.g. at home) -->
+                        <!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-changelog-plugin</artifactId> 
+                            <version>${changelog.version}</version> <configuration> <username>${svn.username}</username> <password>${svn.password}</password> 
+                            </configuration> </plugin> -->
+                    </reportPlugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<profiles>
-		<profile>
-			<id>benchmark</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.openjdk.jmh</groupId>
-					<artifactId>jmh-generator-annprocess</artifactId>
-					<version>${jmh.version}</version>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>exec-maven-plugin</artifactId>
-						<version>${exec.version}</version>
-						<executions>
-							<execution>
-								<id>run-benchmarks</id>
-								<phase>integration-test</phase>
-								<goals>
-									<goal>exec</goal>
-								</goals>
-								<configuration>
-									<classpathScope>test</classpathScope>
-									<executable>java</executable>
-									<arguments>
-										<argument>-classpath</argument>
-										<classpath />
-										<argument>org.openjdk.jmh.Main</argument>
-										<!-- -h for help -->
+    <profiles>
+        <profile>
+            <id>benchmark</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>${jmh.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.version}</version>
+                        <executions>
+                            <execution>
+                                <id>run-benchmarks</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathScope>test</classpathScope>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <classpath />
+                                        <argument>org.openjdk.jmh.Main</argument>
+                                        <!-- -h for help -->
                                         <argument>-f</argument>
                                         <argument>1</argument>
-										<argument>-i</argument>
-										<argument>10</argument>
-										<argument>-wi</argument>
-										<argument>8</argument>
-										<argument>-jvmArgs</argument>
-										<argument>-Xmx512m</argument>
-									</arguments>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+                                        <argument>-i</argument>
+                                        <argument>10</argument>
+                                        <argument>-wi</argument>
+                                        <argument>8</argument>
+                                        <argument>-jvmArgs</argument>
+                                        <argument>-Xmx512m</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
-	<repositories>
-		<repository>
-			<id>rxjava-snapshots</id>
-			<name>rxjava-snapshots</name>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<url>https://oss.jfrog.org/libs-snapshot</url>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>rxjava-snapshots</id>
+            <name>rxjava-snapshots</name>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <url>https://oss.jfrog.org/libs-snapshot</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/src/main/java/com/github/davidmoten/rx/Processes.java
+++ b/src/main/java/com/github/davidmoten/rx/Processes.java
@@ -6,8 +6,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import com.github.davidmoten.util.Optional;
 
@@ -71,13 +69,19 @@ public final class Processes {
                     @Override
                     public void call(Subscriber<? super byte[]> sub) {
                         try {
+                            // TODO waitFor does not exist pre 1.8 with timeout!
+                            // parameters.waitForMs().get(),TimeUnit.MILLISECONDS);
+
                             if (parameters.waitForMs().isPresent()) {
-                                boolean finished = process.waitFor(parameters.waitForMs().get(),
-                                        TimeUnit.MILLISECONDS);
-                                if (!finished) {
-                                    sub.onError(new TimeoutException("process timed out"));
-                                    return;
-                                }
+                                // boolean finished = process.waitFor(
+                                // parameters.waitForMs().get(),
+                                // TimeUnit.MILLISECONDS);
+                                // if (!finished) {
+                                // sub.onError(new TimeoutException("process
+                                // timed out"));
+                                // return;
+                                // }
+                                sub.onError(new IllegalArgumentException("not implemented yet"));
                             } else {
                                 int exitCode = process.waitFor();
                                 if (exitCode != 0)
@@ -103,6 +107,8 @@ public final class Processes {
     }
 
     public static class ProcessException extends RuntimeException {
+        private static final long serialVersionUID = 722422557667123473L;
+
         private final int exitCode;
 
         public ProcessException(int exitCode) {

--- a/src/test/java/com/github/davidmoten/rx/internal/operators/TransformerStateMachineTest.java
+++ b/src/test/java/com/github/davidmoten/rx/internal/operators/TransformerStateMachineTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import com.github.davidmoten.rx.Transformers;
+import com.github.davidmoten.rx.slf4j.Logging;
 
 import rx.Observable;
 import rx.Observable.Transformer;
@@ -162,6 +164,7 @@ public class TransformerStateMachineTest {
     public void testForMemoryLeaks() {
         int n = 10000000;
         int count = Observable.range(1, n)
+                .lift(Logging.<Integer> logger().showMemory().every(1, TimeUnit.SECONDS).log())
                 .compose(Transformers.toListWhile(new Func2<List<Integer>, Integer, Boolean>() {
                     @Override
                     public Boolean call(List<Integer> list, Integer t) {

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger= INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+
+# Print the date in ISO 8601 format
+#log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+
+# Print only messages of level WARN or above in the package com.foo.
+#log4j.logger.com.mchange=DEBUG


### PR DESCRIPTION
For each item entering the state machine the items emitted from the state machine were buffered into a list and only emitted once the entering item was fully processed. At that point notifications were flatmapped and then dematerialized.

The old technique is to to do this:

*  `materialize` -> `scan` -> `flatMap` -> `dematerialize`

The new technique is to do this:

* `materialize` -> `flatMap` using `Observable.create` and `onBackpressureBuffer` -> `dematerialize`

