### PR TITLE
Operator to continue after an onComplete or onError with another seq

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/internal/operators/OperatorOnTerminateResume.java
+++ b/src/main/java/com/github/davidmoten/rx/internal/operators/OperatorOnTerminateResume.java
@@ -1,0 +1,138 @@
+package com.github.davidmoten.rx.internal.operators;
+
+import rx.*;
+import rx.Observable.*;
+import rx.exceptions.*;
+import rx.functions.Func1;
+import rx.internal.producers.ProducerArbiter;
+
+/**
+ * Switches to different Observables if the main source completes or signals an error.
+ *
+ * @param <T> the value type
+ */
+public final class OperatorOnTerminateResume<T> implements Transformer<T, T> {
+    
+    final Func1<Throwable, Observable<T>> onError;
+    
+    final Observable<T> onCompleted;
+
+    public OperatorOnTerminateResume(Func1<Throwable, Observable<T>> onError, Observable<T> onCompleted) {
+        this.onError = onError;
+        this.onCompleted = onCompleted;
+    }
+
+    @Override
+    public Observable<T> call(final Observable<T> o) {
+        return Observable.create(new OnSubscribe<T>() {
+            @Override
+            public void call(Subscriber<? super T> t) {
+                OnTerimateResumeSubscriber<T> parent = new OnTerimateResumeSubscriber<T>(t, onError, onCompleted);
+                
+                t.add(parent);
+                t.setProducer(parent.arbiter);
+                
+                o.unsafeSubscribe(parent);
+            }
+        });
+    }
+    
+    static final class OnTerimateResumeSubscriber<T> extends Subscriber<T> {
+
+        final Subscriber<? super T> actual;
+        
+        final Func1<Throwable, Observable<T>> onError;
+        
+        final Observable<T> onCompleted;
+
+        final ProducerArbiter arbiter;
+        
+        long produced;
+        
+        public OnTerimateResumeSubscriber(Subscriber<? super T> actual, Func1<Throwable, 
+                Observable<T>> onError,
+                Observable<T> onCompleted) {
+            this.arbiter = new ProducerArbiter();
+            this.actual = actual;
+            this.onError = onError;
+            this.onCompleted = onCompleted;
+        }
+
+        @Override
+        public void onNext(T t) {
+            produced++;
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            long p = produced;
+            if (p != 0L) {
+                arbiter.produced(p);
+            }
+            
+            Observable<T> o;
+            
+            try {
+                o = onError.call(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                
+                actual.onError(new CompositeException(e, ex));
+                
+                return;
+            }
+            
+            if (o == null) {
+                actual.onError(new NullPointerException("The onError function returned a null Observable."));
+            } else {
+                o.unsafeSubscribe(new ResumeSubscriber<T>(actual, arbiter));
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            long p = produced;
+            if (p != 0L) {
+                arbiter.produced(p);
+            }
+            onCompleted.unsafeSubscribe(new ResumeSubscriber<T>(actual, arbiter));
+        }
+        
+        @Override
+        public void setProducer(Producer p) {
+            arbiter.setProducer(p);
+        }
+        
+        static final class ResumeSubscriber<T> extends Subscriber<T> {
+            final Subscriber<? super T> actual;
+            
+            final ProducerArbiter arbiter;
+
+            public ResumeSubscriber(Subscriber<? super T> actual, ProducerArbiter arbiter) {
+                this.actual = actual;
+                this.arbiter = arbiter;
+            }
+
+            @Override
+            public void onCompleted() {
+                actual.onCompleted();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
+
+            @Override
+            public void onNext(T t) {
+                actual.onNext(t);
+            }
+
+            @Override
+            public void setProducer(Producer p) {
+                arbiter.setProducer(p);
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/davidmoten/rx/internal/operators/OperatorOnTerminateResumeTest.java
+++ b/src/test/java/com/github/davidmoten/rx/internal/operators/OperatorOnTerminateResumeTest.java
@@ -1,0 +1,129 @@
+package com.github.davidmoten.rx.internal.operators;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
+
+public class OperatorOnTerminateResumeTest {
+
+    @Test
+    public void mainCompletes() {
+        
+        Transformer<Integer, Integer> op = new OperatorOnTerminateResume<Integer>(new Func1<Throwable, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Throwable e) {
+                return Observable.just(11);
+            }
+        }, Observable.just(12));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 10)
+        .compose(op)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void mainCompletesBackpressure() {
+        
+        Transformer<Integer, Integer> op = new OperatorOnTerminateResume<Integer>(new Func1<Throwable, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Throwable e) {
+                return Observable.just(11);
+            }
+        }, Observable.just(12));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, 10)
+        .compose(op)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(2);
+
+        ts.assertValues(1, 2);
+
+        ts.requestMore(5);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7);
+
+        ts.requestMore(3);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        ts.requestMore(1);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void mainErrors() {
+        
+        Transformer<Integer, Integer> op = new OperatorOnTerminateResume<Integer>(new Func1<Throwable, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Throwable e) {
+                return Observable.just(11);
+            }
+        }, Observable.just(12));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        
+        Observable.range(1, 10).concatWith(Observable.<Integer>error(new IOException()))
+        .compose(op)
+        .subscribe(ts);
+        
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+
+    @Test
+    public void mainErrorsBackpressure() {
+        
+        Transformer<Integer, Integer> op = new OperatorOnTerminateResume<Integer>(new Func1<Throwable, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> call(Throwable e) {
+                return Observable.just(11);
+            }
+        }, Observable.just(12));
+        
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+        
+        Observable.range(1, 10).concatWith(Observable.<Integer>error(new IOException()))
+        .compose(op)
+        .subscribe(ts);
+        
+        ts.assertNoValues();
+        
+        ts.requestMore(2);
+
+        ts.assertValues(1, 2);
+
+        ts.requestMore(5);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7);
+
+        ts.requestMore(3);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        ts.requestMore(1);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        ts.assertNoErrors();
+        ts.assertCompleted();
+    }
+}


### PR DESCRIPTION
This adds an operator that allows continuing with another Observable when the main source completes or signals an error. This is aimed at replacing this pattern:

```java
source.concatWith(onCompleteObservable).onErrorResumeNext(e -> onErrorObservable);
```

The problem with this is that if an error in `onCompleteObservable` triggers the `onErrorResumeNext` or if swapped, the completion of `onErrorObservable` triggers `concatWith`.